### PR TITLE
Add "'s" to "Master Thesis"

### DIFF
--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -80,7 +80,7 @@
 
 % style options :
 %	"english"   ... Written in english.  Default is Japanese.
-%	"master"    ... Master thesis.  Default is B.E. thesis.
+%	"master"    ... Master's thesis.  Default is B.E. thesis.
 %	"withinsec" ... Make counters run in a \section.
 
 \newif\ifDS@english \DS@englishfalse
@@ -338,7 +338,7 @@
 \ifDS@english
 \def\@title{\@etitle} \def\@titleforabst{\@etitleforabst}
 \def\@author{\@eauthor}
-\def\mkt@masterthesis{Master Thesis}
+\def\mkt@masterthesis{Master's Thesis}
 \def\mkt@supervisor{Supervisor}
 \def\mkt@department{Department of \@department \\		% 2.10 (3)
 	Graduate School of Informatics\\


### PR DESCRIPTION
Fixes a typo on the title page.